### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/guestbook/guestbook.yaml
+++ b/guestbook/guestbook.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: guestbook
-        image: 'k8s.gcr.io/guestbook:v3'
+        image: 'registry.k8s.io/guestbook:v3'
         env:
         - name: "VERSION"
           value: "v1"

--- a/guestbook/redis.yaml
+++ b/guestbook/redis.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-master
-        image: 'k8s.gcr.io/redis:e2e'
+        image: 'registry.k8s.io/redis:e2e'
         ports:
         - name: redis-server
           containerPort: 6379
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: redis-slave
-        image: 'k8s.gcr.io/redis-slave:v2'
+        image: 'registry.k8s.io/redis-slave:v2'
         ports:
         - name: redis-server
           containerPort: 6379


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

cc @FillZpp